### PR TITLE
Add outdated warning prior to archiving repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Swift on Windows Samples Apps
 
+> [!WARNING]
+> This project uses an outdated snapshot of a subset of WinRT projections generated with [swift-winrt](https://github.com/thebrowsercompany/swift-winrt), provided for illustration purposes. To use WinRT APIs in your Swift project, we recommend using [swift-winrt](https://github.com/thebrowsercompany/swift-winrt) directly to generate your own projections.
+
 Sample apps for Swift on Windows, showcasing how to build Windows Apps using the [Windows App SDK](https://github.com/microsoft/windowsappsdk) through the [Swift/WinRT](https://github.com/thebrowsercompany/swift-winrt) language projection.
 
 ## Setup


### PR DESCRIPTION
I will archive this repository after merging this change. Folks have been reporting issues with our pregenerated projections repos and we're neither keeping them updated nor providing ongoing support, so better avoid confusion by archiving the repos.